### PR TITLE
Handle network errors

### DIFF
--- a/satisfactory/game.py
+++ b/satisfactory/game.py
@@ -1,16 +1,22 @@
+import logging
 import random
 from datetime import datetime
 from typing import Dict, List
 
 import requests
 import vdf
+from prometheus_client import Counter
 from steam.client import SteamClient
 from steam.core.msg import MsgProto
+from steam.enums import EResult
 from steam.enums.emsg import EMsg
 from steam.utils.proto import proto_to_dict
 
 NEWS_URL = "https://store.steampowered.com/events/ajaxgetadjacentpartnerevents/?appid=526870&count_after=10"
 APPID = 1690800  # Steam ID of Satisfactory
+
+PROM_STEAM_CONNECT = Counter("satisfactory_bot_steam_connect", "Status of Steam client connection attempts", ["status"])
+PROM_STEAM_LOGIN = Counter("satisfactory_bot_steam_login", "Status of Steam client login attempts", ["status"])
 
 QUOTES = [
     "Harvest.",
@@ -28,7 +34,21 @@ QUOTES = [
 def get_versions() -> Dict:
     result = {}
     client = SteamClient()
-    client.anonymous_login()
+
+    if client.connect(retry=1):
+        logging.debug("Steam client connected successfully")
+        PROM_STEAM_CONNECT.labels("success").inc()
+    else:
+        PROM_STEAM_CONNECT.labels("error").inc()
+        raise Exception("Steam client was unable to connect")
+
+    login = client.anonymous_login()
+    PROM_STEAM_LOGIN.labels(login.name).inc()
+    if login == EResult.OK:
+        logging.debug("Steam client logged in successfully")
+    else:
+        raise Exception("Steam client was unable to login")
+
     resp = proto_to_dict(client.send_job_and_wait(MsgProto(EMsg.ClientPICSProductInfoRequest), {"apps": [{"appid": APPID}]}, timeout=10))
     appinfo = vdf.loads(resp["apps"][0].pop("buffer")[:-1].decode("utf-8", "replace"))["appinfo"]
 
@@ -53,7 +73,7 @@ def sanitize_steam_string(text: str) -> str:
 
 def get_patchnotes(age: int = 60) -> List[str]:
     news = []
-    response = requests.get(NEWS_URL)
+    response = requests.get(NEWS_URL, timeout=10)
     response.raise_for_status()
     for event in response.json()["events"]:
         if "patchnotes" in event["announcement_body"]["tags"] and not event["event_name"].startswith("Experimental"):


### PR DESCRIPTION
When the bot failed to connect to the Steam API it sometimes got stuck
forever and a restart was required to fix it. Now it should timeout and
fail properly.

Somewhat related this change also configures a timeout for the HTTP
request used to fetch update news.