### PR TITLE
Remove gevent monkey patching

### DIFF
--- a/satisfactory/cli.py
+++ b/satisfactory/cli.py
@@ -1,8 +1,3 @@
-from gevent import monkey
-
-# Necessary to make the steam api client work in a different thread.
-monkey.patch_all()
-
 import logging
 
 import click

--- a/satisfactory/game.py
+++ b/satisfactory/game.py
@@ -57,6 +57,9 @@ def get_versions() -> Dict:
         if not value.get("pwdrequired"):
             result[branch] = {"timeupdated": datetime.utcfromtimestamp(int(value["timeupdated"])), "buildid": value["buildid"]}
 
+    client.logout()
+    client.disconnect()
+
     return result
 
 


### PR DESCRIPTION
In the past I added it to solve issues with the Steam library running in
a different thread. I am not sure why I do not need it anymore, but it
works perfectly without it now. Not using monkey patching also solves
some massive threading stacktraces when terminating the bot.