### PR TITLE
Add Dedicated Gameserver Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The bot checks for new release notes every 60 minutes and posts new release note
 
 If you really want to run the bot, the easiest way is to fork this repository. Create a GitHub personal access token that has write access to the fork and also [create a Telegram bot token](https://core.telegram.org/bots#6-botfather). To run the bot you can either use the existing [bot image](https://github.com/ekeih/satisfactory-bot/pkgs/container/satisfactory-bot%2Fbot) or clone the repository, install the bot manually with `cd satisfactory-bot && pip install .`.
 
+The bot can also query the HTTP API of the dedicated server and send notifications based on it. To enable this you need to provide both the server address and an API Token. A Token can be retrieved by a server admin by running `server.GenerateAPIToken` in the Server Console from within the game's server menu.
+
 Then run the bot: `satisfactory-bot -b $telegram-bot-token -g $github-token -c $telegram-chat-id -r $github-repository`.
 
 ## Credits

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyGithub==2.4.0
 python-telegram-bot[job-queue]==20.8
 requests==2.32.3
 steam[client]==1.4.4
+pyfactorybridge==1.0.1

--- a/satisfactory/chat.py
+++ b/satisfactory/chat.py
@@ -21,7 +21,7 @@ class Bot:
 
     def __init__(self, bot_token: str, chat_id: int, github_client: satisfactory.git.Git or None,
                  youtube_client: satisfactory.youtube.Youtube or None,
-                 server_address: str, server_token: str):
+                 server_address: str or None, server_token: str or None):
         self.chat_id = chat_id
         self.github_client = github_client
         self.youtube_client = youtube_client

--- a/satisfactory/chat.py
+++ b/satisfactory/chat.py
@@ -171,13 +171,10 @@ class Bot:
         if self.gameserver_address is None or self.gameserver_token is None:
             return
 
-        gameserver_address = self.gameserver_address
-        gameserver_token = self.gameserver_token
-
-        from pyfactorybridge import API
-        satisfactory_api_client = API(address=gameserver_address, token=gameserver_token)
-
         try:
+            from pyfactorybridge import API
+            satisfactory_api_client = API(address=self.gameserver_address, token=self.gameserver_token)
+
             server_stats = satisfactory_api_client.query_server_state()
             server_stats = server_stats.get(KEY_SERVER_GAME_STATE, {})
             new_num_connected_players = int(server_stats.get(KEY_SERVER_STATS_NUM_CONNECTED_PLAYERS, 0))

--- a/satisfactory/chat.py
+++ b/satisfactory/chat.py
@@ -77,7 +77,7 @@ class Bot:
     async def check_news_timer(self, context: CallbackContext):
         await self.check_news(context)
 
-    @Summary("satisfactory_bot_check_news_timer", "Time spent running the check_news_timer").time()
+    @Summary("satisfactory_bot_check_server_status_timer", "Time spent running the check_server_status").time()
     async def check_server_status_timer(self, context: CallbackContext):
         await self.check_server_status(context)
 

--- a/satisfactory/chat.py
+++ b/satisfactory/chat.py
@@ -20,10 +20,15 @@ class Bot:
     chat_id = None
 
     def __init__(self, bot_token: str, chat_id: int, github_client: satisfactory.git.Git or None,
-                 youtube_client: satisfactory.youtube.Youtube or None):
+                 youtube_client: satisfactory.youtube.Youtube or None,
+                 server_address: str, server_token: str):
         self.chat_id = chat_id
         self.github_client = github_client
         self.youtube_client = youtube_client
+
+        self.gameserver_address = server_address
+        self.gameserver_token = server_token
+        self.last_server_stats = None
 
         self._app = ApplicationBuilder().token(bot_token).build()
 
@@ -39,6 +44,8 @@ class Bot:
         self._app.job_queue.run_repeating(self.check_news_timer, interval=60 * 60, first=30)
         if self.youtube_client is not None:
             self._app.job_queue.run_repeating(self.check_videos, interval=60 * 60, first=15)
+        if self.gameserver_address is not None and self.gameserver_token is not None:
+            self._app.job_queue.run_repeating(self.check_server_status_timer, interval=60 * 5, first=5)
         self._app.job_queue.run_once(self.send_random_quote_timer, random.randrange(60 * 60 * 24, 60 * 60 * 24 * 7, 1))
         self._app.run_polling()
 
@@ -70,6 +77,10 @@ class Bot:
     async def check_news_timer(self, context: CallbackContext):
         await self.check_news(context)
 
+    @Summary("satisfactory_bot_check_news_timer", "Time spent running the check_news_timer").time()
+    async def check_server_status_timer(self, context: CallbackContext):
+        await self.check_server_status(context)
+
     @Summary("satisfactory_bot_check_videos_timer", "Time spent running the check_videos_timer").time()
     async def check_videos_timer(self, context: CallbackContext):
         await self.check_videos(context)
@@ -93,13 +104,21 @@ class Bot:
                 logging.info("Tagging new %s version: %s", version, version_tag)
                 new_versions_count += 1
                 self.github_client.create_tag(version_tag)
-                await context.bot.send_message(chat_id=self.chat_id, text="Tagged new release <code>%s</code>\n\n%s" % (
-                version_tag, satisfactory.game.get_random_quote()), parse_mode=ParseMode.HTML, disable_notification=True)
+                await context.bot.send_message(
+                    chat_id=self.chat_id,
+                    text="Tagged new release <code>%s</code>\n\n%s" % (
+                        version_tag, satisfactory.game.get_random_quote()),
+                    parse_mode=ParseMode.HTML,
+                    disable_notification=True
+                )
         if new_versions_count == 0 and not context.job:
             # A user triggered the check manually, inform them that there was no new version found.
-            await context.bot.send_message(chat_id=self.chat_id,
-                                           text="No newer versions available, doing nothing.\n\n%s" % (
-                                               satisfactory.game.get_random_quote()), parse_mode=ParseMode.HTML)
+            await context.bot.send_message(
+                chat_id=self.chat_id,
+                text="No newer versions available, doing nothing.\n\n%s" % (
+                    satisfactory.game.get_random_quote()),
+                parse_mode=ParseMode.HTML
+            )
 
     @Summary("satisfactory_bot_check_news", "Time spent running check_news").time()
     async def check_news(self, context: CallbackContext) -> None:
@@ -141,4 +160,38 @@ class Bot:
     async def check_videos(self, context: CallbackContext) -> None:
         videos = self.youtube_client.get_new_videos()
         for video in videos:
-            await context.bot.send_message(chat_id=self.chat_id, text=video, parse_mode=ParseMode.HTML, disable_notification=True)
+            await context.bot.send_message(chat_id=self.chat_id, text=video, parse_mode=ParseMode.HTML,
+                                           disable_notification=True)
+
+    @Summary("satisfactory_bot_check_server_status", "Time spent running check_server_status").time()
+    async def check_server_status(self, context: CallbackContext) -> None:
+        if self.gameserver_address is None or self.gameserver_token is None:
+            return
+
+        gameserver_address = self.gameserver_address
+        gameserver_token = self.gameserver_token
+
+        from pyfactorybridge import API
+        satisfactory_api_client = API(address=gameserver_address, token=gameserver_token)
+
+        try:
+            server_stats = satisfactory_api_client.query_server_state()
+            new_num_connected_players = int(server_stats.get("NumConnectedPlayers", 0))
+            old_num_connected_players = self.last_server_stats.get("NumConnectedPlayers", 0) if self.last_server_stats else 0
+
+            text = None
+            if new_num_connected_players > 0 and new_num_connected_players != old_num_connected_players:
+                text = f"New active players: {new_num_connected_players}"
+            elif new_num_connected_players == 0 and new_num_connected_players != old_num_connected_players:
+                text = f"Server is empty."
+
+            if text is not None:
+                await context.bot.send_message(
+                    chat_id=self.chat_id, text=text,
+                    parse_mode=ParseMode.HTML, disable_notification=True
+                )
+
+            self.last_server_stats = server_stats
+        except Exception as e:
+            logging.error("Failed to query server state: %s", e)
+            return

--- a/satisfactory/chat.py
+++ b/satisfactory/chat.py
@@ -189,7 +189,7 @@ class Bot:
             if text is not None:
                 await context.bot.send_message(
                     chat_id=self.chat_id, text=text,
-                    parse_mode=ParseMode.HTML, disable_notification=new_num_connected_players > 0
+                    parse_mode=ParseMode.HTML, disable_notification=new_num_connected_players == 0
                 )
 
             self.last_server_stats = server_stats

--- a/satisfactory/cli.py
+++ b/satisfactory/cli.py
@@ -19,12 +19,14 @@ CONTEXT_SETTINGS = {
 @click.option("-b", "--bot-token", "bot_token", required=True, default=None, type=str, help="Telegram Bot Token")
 @click.option("-g", "--github-token", "github_token", required=False, default=None, type=str, help="GitHub token to access GitHub")
 @click.option("-y", "--youtube-token", "youtube_token", required=False, default=None, type=str, help="Google API token to access YouTube")
+@click.option("-s", "--server-address", "server_address", required=False, default=None, type=str, help="Satisfactory Dedicated Server Address")
+@click.option("-t", "--server-token", "server_token", required=False, default=None, type=str, help="Satisfactory Dedicated Server Address")
 @click.option("-c", "--chat-id", "chat_id", required=True, default=None, type=int, help="Chat ID to send messages to")
 @click.option("-r", "--repository", "repository", required=True, default="ekeih/satisfactory-bot", type=str, help="GitHub repository")
 @click.option("-a", "--metrics-address", required=True, default="0.0.0.0", type=str, help="IP address to serve metrics on")
 @click.option("-p", "--metrics-port", required=True, default=8000, type=int, help="Port to serve metrics on")
 @click.option("-v", "--version", is_flag=True, type=bool, help="Show version and exit")
-def cli(bot_token: str, github_token: str, youtube_token: str, chat_id: int, repository: str, metrics_address: str, metrics_port: int, version: bool) -> None:
+def cli(bot_token: str, github_token: str, youtube_token: str, server_address: str, server_token: str, chat_id: int, repository: str, metrics_address: str, metrics_port: int, version: bool) -> None:
     installed_version=metadata.version('satisfactory_bot')
     if version:
         print(installed_version)
@@ -41,7 +43,14 @@ def cli(bot_token: str, github_token: str, youtube_token: str, chat_id: int, rep
         if youtube_token is not None:
             youtube_client = satisfactory.youtube.Youtube(youtube_token)
 
-        bot = satisfactory.chat.Bot(bot_token=bot_token, chat_id=chat_id, github_client=github_client, youtube_client=youtube_client)
+        bot = satisfactory.chat.Bot(
+            bot_token=bot_token,
+            chat_id=chat_id,
+            github_client=github_client,
+            youtube_client=youtube_client,
+            server_address=server_address,
+            server_token=server_token
+        )
         bot.start()
 
 

--- a/satisfactory/cli.py
+++ b/satisfactory/cli.py
@@ -20,7 +20,7 @@ CONTEXT_SETTINGS = {
 @click.option("-g", "--github-token", "github_token", required=False, default=None, type=str, help="GitHub token to access GitHub")
 @click.option("-y", "--youtube-token", "youtube_token", required=False, default=None, type=str, help="Google API token to access YouTube")
 @click.option("-s", "--server-address", "server_address", required=False, default=None, type=str, help="Satisfactory Dedicated Server Address")
-@click.option("-t", "--server-token", "server_token", required=False, default=None, type=str, help="Satisfactory Dedicated Server Address")
+@click.option("-t", "--server-token", "server_token", required=False, default=None, type=str, help="Satisfactory Dedicated Server Authentication Token")
 @click.option("-c", "--chat-id", "chat_id", required=True, default=None, type=int, help="Chat ID to send messages to")
 @click.option("-r", "--repository", "repository", required=True, default="ekeih/satisfactory-bot", type=str, help="GitHub repository")
 @click.option("-a", "--metrics-address", required=True, default="0.0.0.0", type=str, help="IP address to serve metrics on")


### PR DESCRIPTION
This PR adds a a direct integration to the dedicated gameserver HTTP API via [pyfactorybridge](https://github.com/Jayy001/PyFactoryBridge).

The current implementation is suppsed to regularly check the server stats and inform about changing player counts.
Since the API allows for much more than just querying the gameserver stats, other features could be added, like f.ex. bot commands to restart the server.

This is how the messages look like in telegram:
![image](https://github.com/user-attachments/assets/ed800070-49d7-4e85-bd77-966430d8b400)
